### PR TITLE
Fix CVE-2018-3721

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,9 +182,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lru-cache": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "main": "data.json",
   "devDependencies": {
     "ajv-cli": "^1.1.1",
-    "lodash": "^4.16.6"
+    "lodash": "^4.17.11"
   }
 }


### PR DESCRIPTION
Bumped version of lodash to 4.7.11 to address Modification of Assumed
Immutable Data (MAID) vulnerability raised in CVE-2018-3721.