### PR TITLE
Fix recipe typos

### DIFF
--- a/data/everyday_anarchy.json
+++ b/data/everyday_anarchy.json
@@ -95,7 +95,7 @@
           "value": 12.5,
           "unit": "grams"
         },
-        "add": "midele",
+        "add": "middle",
         "attribute": "flavour"
       },
       {

--- a/data/zipcode.json
+++ b/data/zipcode.json
@@ -103,7 +103,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "]Saflager W-34/70"
+    "yeast": "Saflager W-34/70"
   },
   "food_pairing": [
     "Goat's cheese salad",


### PR DESCRIPTION
Fixes a typo in one of the hop additions for Everyday Anarchy.

Also fixes a typo in the yeast name for Zipcode.