### PR TITLE
Clean up ingredients and fix various typos

### DIFF
--- a/data/77_lager.json
+++ b/data/77_lager.json
@@ -101,7 +101,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "Wyeast Pilsner Strain 2007™"
+    "yeast": "Wyeast 2007 - Pilsen Lager™"
   },
   "food_pairing": [
     "Aromatic spicy red thai curry",

--- a/data/ab04.json
+++ b/data/ab04.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 10,
           "unit": "kilograms"
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Flaked Oat Malt",
+        "name": "Flaked Oats",
         "amount": {
           "value": 1.88,
           "unit": "kilograms"

--- a/data/ab06.json
+++ b/data/ab06.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 6.13,
           "unit": "kilograms"

--- a/data/ab07.json
+++ b/data/ab07.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Oats",
+        "name": "Flaked Oats",
         "amount": {
           "value": 1.88,
           "unit": "kilograms"

--- a/data/ab11.json
+++ b/data/ab11.json
@@ -42,14 +42,14 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Extra pale - Sprint Blend",
+        "name": "Extra Pale - Spring Blend",
         "amount": {
           "value": 8.75,
           "unit": "kilograms"
         }
       },
       {
-        "name": "Cara",
+        "name": "Caramalt",
         "amount": {
           "value": 1.25,
           "unit": "kilograms"

--- a/data/ab20.json
+++ b/data/ab20.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Premium Eng Caramalt",
+        "name": "Premium English Caramalt",
         "amount": {
           "value": 0.2,
           "unit": "kilograms"

--- a/data/ab21.json
+++ b/data/ab21.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Brown Malt",
+        "name": "Brown",
         "amount": {
           "value": 1,
           "unit": "kilograms"

--- a/data/ab22.json
+++ b/data/ab22.json
@@ -151,7 +151,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Roast Pheasant With Savoy Cabbage",

--- a/data/ab22.json
+++ b/data/ab22.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Carafa Special III",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.120,
           "unit": "kilograms"

--- a/data/ab23.json
+++ b/data/ab23.json
@@ -122,7 +122,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Stilton and Walnut Welsh Rarebit.",

--- a/data/ab24.json
+++ b/data/ab24.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Double Roast Crystal",
+        "name": "Double Roasted Crystal",
         "amount": {
           "value": 0.72,
           "unit": "kilograms"

--- a/data/ab24.json
+++ b/data/ab24.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Crystal Medium",
+        "name": "Medium Crystal",
         "amount": {
           "value": 0.48,
           "unit": "kilograms"

--- a/data/ab24.json
+++ b/data/ab24.json
@@ -147,7 +147,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "S’mores with smoked marshmallows",

--- a/data/ab25.json
+++ b/data/ab25.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Extra Darl Crystal",
+        "name": "Extra Dark Crystal",
         "amount": {
           "value": 0.360,
           "unit": "kilograms"

--- a/data/alice_porter.json
+++ b/data/alice_porter.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Carafa 1",
+        "name": "Carafa Special Malt Type 1",
         "amount": {
           "value": 0.44,
           "unit": "kilograms"

--- a/data/american_wheat.json
+++ b/data/american_wheat.json
@@ -83,7 +83,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "Wyeast 1010 American Wheat™"
+    "yeast": "Wyeast 1010 - American Wheat™"
   },
   "food_pairing": [
     "Strawberry and citrus salad",

--- a/data/avery_brown_dredge.json
+++ b/data/avery_brown_dredge.json
@@ -85,7 +85,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "Wyeast Pilsner Lager 2007™"
+    "yeast": "Wyeast 2007 - Pilsen Lager™"
   },
   "food_pairing": [
     "Vietnamese squid salad",

--- a/data/baby_dogma.json
+++ b/data/baby_dogma.json
@@ -118,7 +118,7 @@
         "attribute": "bitter"
       },
       {
-        "name": "Hallertauer Mittelfrüh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 6,
           "unit": "grams"

--- a/data/baltic_fleet.json
+++ b/data/baltic_fleet.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Carafa Special Type III",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.180,
           "unit": "kilograms"

--- a/data/bashah.json
+++ b/data/bashah.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Carafa 3",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.48,
           "unit": "kilograms"

--- a/data/bavarian_weizen.json
+++ b/data/bavarian_weizen.json
@@ -126,7 +126,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "WLP351 Bavarian Weizen"
+    "yeast": "WLP351 - Bavarian Weizen"
   },
   "food_pairing": [
     "Spicy paella",

--- a/data/beatnik.json
+++ b/data/beatnik.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Marris Otter",
+        "name": "Maris Otter",
         "amount": {
           "value": 5,
           "unit": "kilograms"
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Crystal Dark",
+        "name": "Dark Crystal",
         "amount": {
           "value": 0.27,
           "unit": "kilograms"

--- a/data/belgian_trappist.json
+++ b/data/belgian_trappist.json
@@ -126,7 +126,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "WLP500 Monastery Ale"
+    "yeast": "WLP500 - Monastery Ale"
   },
   "food_pairing": [
     "Roast beef with spicy jus",

--- a/data/berliner_weisse_with_yuzu.json
+++ b/data/berliner_weisse_with_yuzu.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Propino Pale Malt for kettle 0.03kg souring",
+        "name": "Propino Pale Malt for kettle souring",
         "amount": {
           "value": 0.03,
           "unit": "kilograms"

--- a/data/bitch_please.json
+++ b/data/bitch_please.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "CaraHell",
+        "name": "Carahell",
         "amount": {
           "value": 0.18,
           "unit": "kilograms"

--- a/data/black_dog.json
+++ b/data/black_dog.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Extra Pale Spring Blend",
+        "name": "Extra Pale - Spring Blend",
         "amount": {
           "value": 4.15,
           "unit": "kilograms"

--- a/data/black_dog.json
+++ b/data/black_dog.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Chocolate Malt",
+        "name": "Chocolate",
         "amount": {
           "value": 0.38,
           "unit": "kilograms"

--- a/data/black_eye_joe.json
+++ b/data/black_eye_joe.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Extra Pale Ale Malt",
+        "name": "Extra Pale",
         "amount": {
           "value": 2.7,
           "unit": "kilograms"

--- a/data/black_eyed_king_imp_vietnamese_coffee_edition.json
+++ b/data/black_eyed_king_imp_vietnamese_coffee_edition.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Cara",
+        "name": "Caramalt",
         "amount": {
           "value": 1.25,
           "unit": "kilograms"

--- a/data/black_tokyo_horizon.json
+++ b/data/black_tokyo_horizon.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Smoked",
+        "name": "Smoked Malt",
         "amount": {
           "value": 0.25,
           "unit": "kilograms"

--- a/data/blitz_saison.json
+++ b/data/blitz_saison.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Oats",
+        "name": "Flaked Oats",
         "amount": {
           "value": 0.25,
           "unit": "kilograms"

--- a/data/blitz_saison.json
+++ b/data/blitz_saison.json
@@ -63,7 +63,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Marris Otter",
+        "name": "Maris Otter",
         "amount": {
           "value": 3,
           "unit": "kilograms"

--- a/data/blitz_series.json
+++ b/data/blitz_series.json
@@ -56,7 +56,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 1.6,
           "unit": "kilograms"

--- a/data/blonde_export_stout.json
+++ b/data/blonde_export_stout.json
@@ -72,7 +72,7 @@
     ],
     "hops": [
       {
-        "name": "Magnun",
+        "name": "Magnum",
         "amount": {
           "value": 7,
           "unit": "grams"

--- a/data/blonde_export_stout.json
+++ b/data/blonde_export_stout.json
@@ -135,7 +135,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Duck Crackling",

--- a/data/blonde_export_stout.json
+++ b/data/blonde_export_stout.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Smoked",
+        "name": "Smoked Malt",
         "amount": {
           "value": 0.200,
           "unit": "kilograms"

--- a/data/brewdog_vs_beavertown.json
+++ b/data/brewdog_vs_beavertown.json
@@ -84,7 +84,7 @@
         }
       },
       {
-        "name": "Black",
+        "name": "Black Malt",
         "amount": {
           "value": 0.1,
           "unit": "kilograms"

--- a/data/brixton_porter.json
+++ b/data/brixton_porter.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Black",
+        "name": "Black Malt",
         "amount": {
           "value": 0.13,
           "unit": "kilograms"

--- a/data/cascade_centennial_willamette_ipa.json
+++ b/data/cascade_centennial_willamette_ipa.json
@@ -70,14 +70,14 @@
         }
       },
       {
-        "name": "Dextrin",
+        "name": "Dextrin Malt",
         "amount": {
           "value": 0.63,
           "unit": "kilograms"
         }
       },
       {
-        "name": "Oats",
+        "name": "Flaked Oats",
         "amount": {
           "value": 0.63,
           "unit": "kilograms"

--- a/data/cascade_centennial_willamette_ipa.json
+++ b/data/cascade_centennial_willamette_ipa.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Dextrin Malt",
+        "name": "Dextrin",
         "amount": {
           "value": 0.63,
           "unit": "kilograms"

--- a/data/casino_rye_ale.json
+++ b/data/casino_rye_ale.json
@@ -101,7 +101,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1056 – American Ale™"
+    "yeast": "Wyeast 1056 - American Ale™"
   },
   "food_pairing": [
     "Crab Cakes",

--- a/data/catherines_pony.json
+++ b/data/catherines_pony.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Carafa 2",
+        "name": "Carafa Special Malt Type 2",
         "amount": {
           "value": 0.48,
           "unit": "kilograms"

--- a/data/choco_libre.json
+++ b/data/choco_libre.json
@@ -147,7 +147,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "™"
+    "yeast": "Wyeast 1056 - American Ale™"
   },
   "food_pairing": [
     "Habanero pulled pork",

--- a/data/choco_libre.json
+++ b/data/choco_libre.json
@@ -84,7 +84,7 @@
         }
       },
       {
-        "name": "Carafa Special I",
+        "name": "Carafa Special Malt Type 1",
         "amount": {
           "value": 0.369,
           "unit": "kilograms"

--- a/data/citra.json
+++ b/data/citra.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Xpale",
+        "name": "Extra Pale",
         "amount": {
           "value": 6.38,
           "unit": "kilograms"

--- a/data/cocoa_psycho.json
+++ b/data/cocoa_psycho.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Black",
+        "name": "Black Malt",
         "amount": {
           "value": 1.25,
           "unit": "kilograms"

--- a/data/coffee_imperial_stout.json
+++ b/data/coffee_imperial_stout.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Roast Barley",
+        "name": "Roasted Barley",
         "amount": {
           "value": 0.31,
           "unit": "kilograms"

--- a/data/crew_brew.json
+++ b/data/crew_brew.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Marris Otter",
+        "name": "Maris Otter",
         "amount": {
           "value": 4,
           "unit": "kilograms"

--- a/data/cult_lager.json
+++ b/data/cult_lager.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Lager",
+        "name": "Lager Malt",
         "amount": {
           "value": 4.66,
           "unit": "kilograms"

--- a/data/dead_metaphor.json
+++ b/data/dead_metaphor.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Black",
+        "name": "Black Malt",
         "amount": {
           "value": 0.31,
           "unit": "kilograms"

--- a/data/deaf_mermaid.json
+++ b/data/deaf_mermaid.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 4.38,
           "unit": "kilograms"

--- a/data/declassified_demi_god.json
+++ b/data/declassified_demi_god.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Smoked",
+        "name": "Smoked Malt",
         "amount": {
           "value": 0.480,
           "unit": "kilograms"

--- a/data/declassified_demi_god.json
+++ b/data/declassified_demi_god.json
@@ -165,7 +165,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Mole Mexican chilli beef",

--- a/data/dog_g.json
+++ b/data/dog_g.json
@@ -84,14 +84,14 @@
         }
       },
       {
-        "name": "Carafa Special Malt Type I",
+        "name": "Carafa Special Malt Type 1",
         "amount": {
           "value": 0.5,
           "unit": "kilograms"
         }
       },
       {
-        "name": "Carafa Special Malt Type III",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.5,
           "unit": "kilograms"

--- a/data/dogma.json
+++ b/data/dogma.json
@@ -98,7 +98,7 @@
         }
       },
       {
-        "name": "Smoked",
+        "name": "Smoked Malt",
         "amount": {
           "value": 0.06,
           "unit": "kilograms"

--- a/data/gin_blitz.json
+++ b/data/gin_blitz.json
@@ -115,7 +115,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1056 – American Ale™"
+    "yeast": "Wyeast 1056 - American Ale™"
   },
   "food_pairing": [
     "Game Terrine with Pickles",

--- a/data/gin_blitz.json
+++ b/data/gin_blitz.json
@@ -63,7 +63,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Marris Otter",
+        "name": "Maris Otter",
         "amount": {
           "value": 1.5,
           "unit": "kilograms"

--- a/data/growler.json
+++ b/data/growler.json
@@ -92,7 +92,7 @@
         "attribute": "aroma"
       }
     ],
-    "yeast": "Wyeast 2007 - Pilsner™"
+    "yeast": "Wyeast 2007 - Pilsen Lager™"
   },
   "food_pairing": [
     "Havarti cheese",

--- a/data/growler.json
+++ b/data/growler.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 4,
           "unit": "kilograms"

--- a/data/hello_my_name_is_agnetha.json
+++ b/data/hello_my_name_is_agnetha.json
@@ -130,7 +130,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Pork meatballs",

--- a/data/hello_my_name_is_aune.json
+++ b/data/hello_my_name_is_aune.json
@@ -130,7 +130,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Spinach and feta salad",

--- a/data/hello_my_name_is_helga.json
+++ b/data/hello_my_name_is_helga.json
@@ -121,7 +121,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Roast pork chops",

--- a/data/hello_my_name_is_ingrid_2016.json
+++ b/data/hello_my_name_is_ingrid_2016.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Cara Malt",
+        "name": "Caramalt",
         "amount": {
           "value": 0.7,
           "unit": "kilograms"

--- a/data/hello_my_name_is_lieke.json
+++ b/data/hello_my_name_is_lieke.json
@@ -130,7 +130,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Peking duck",

--- a/data/hello_my_name_is_maria.json
+++ b/data/hello_my_name_is_maria.json
@@ -130,7 +130,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Stir-fried chicken",

--- a/data/hello_my_name_is_marianne.json
+++ b/data/hello_my_name_is_marianne.json
@@ -130,7 +130,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Smoked venison stew",

--- a/data/hello_my_name_is_niamh.json
+++ b/data/hello_my_name_is_niamh.json
@@ -130,7 +130,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Grilled sea bass fillet",

--- a/data/hello_my_name_is_sari.json
+++ b/data/hello_my_name_is_sari.json
@@ -130,7 +130,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Steamed cod with ginger and spring onions",

--- a/data/hello_my_name_is_sofia.json
+++ b/data/hello_my_name_is_sofia.json
@@ -130,7 +130,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Deep-fried calamari",

--- a/data/homicidal_puppet_help_desk.json
+++ b/data/homicidal_puppet_help_desk.json
@@ -92,7 +92,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Stilton and Walnut Welsh Rarebit.",

--- a/data/honey_and_lemon_blitz.json
+++ b/data/honey_and_lemon_blitz.json
@@ -85,7 +85,7 @@
         }
       },
       {
-        "name": "Oats",
+        "name": "Flaked Oats",
         "amount": {
           "value": 0.2,
           "unit": "kilograms"

--- a/data/hop_rocker.json
+++ b/data/hop_rocker.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Extra Pale Maris Otter",
+        "name": "Maris Otter Extra Pale",
         "amount": {
           "value": 3.78,
           "unit": "kilograms"

--- a/data/hoppy_saison.json
+++ b/data/hoppy_saison.json
@@ -84,7 +84,7 @@
         }
       },
       {
-        "name": "Acidulated malt",
+        "name": "Acidulated Malt",
         "amount": {
           "value": 0.63,
           "unit": "kilograms"

--- a/data/i_wanna_be_your_dog.json
+++ b/data/i_wanna_be_your_dog.json
@@ -84,14 +84,14 @@
         }
       },
       {
-        "name": "Dextrin",
+        "name": "Dextrin Malt",
         "amount": {
           "value": 0.480,
           "unit": "kilograms"
         }
       },
       {
-        "name": "Dpouble Roasted Crystal",
+        "name": "Double Roasted Crystal",
         "amount": {
           "value": 0.240,
           "unit": "kilograms"

--- a/data/india_session_lager.json
+++ b/data/india_session_lager.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Dextrin",
+        "name": "Dextrin Malt",
         "amount": {
           "value": 0.38,
           "unit": "kilograms"

--- a/data/india_session_lager.json
+++ b/data/india_session_lager.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Dextrin Malt",
+        "name": "Dextrin",
         "amount": {
           "value": 0.38,
           "unit": "kilograms"

--- a/data/interstate_vienna_lager.json
+++ b/data/interstate_vienna_lager.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "CaraRed",
+        "name": "Carared",
         "amount": {
           "value": 0.180,
           "unit": "kilograms"
@@ -88,7 +88,7 @@
         "attribute": "Bittering"
       },
       {
-        "name": "Hallertauer Mittelfruh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 20,
           "unit": "grams"

--- a/data/jasmine_ipa.json
+++ b/data/jasmine_ipa.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 4.69,
           "unit": "kilograms"

--- a/data/jet_black_heart.json
+++ b/data/jet_black_heart.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Black",
+        "name": "Black Malt",
         "amount": {
           "value": 0.19,
           "unit": "kilograms"

--- a/data/jet_trash.json
+++ b/data/jet_trash.json
@@ -56,14 +56,14 @@
         }
       },
       {
-        "name": "Dextrin",
+        "name": "Dextrin Malt",
         "amount": {
           "value": 0.240,
           "unit": "kilograms"
         }
       },
       {
-        "name": "CaraRed",
+        "name": "Carared",
         "amount": {
           "value": 0.240,
           "unit": "kilograms"

--- a/data/jinx_pale_ale.json
+++ b/data/jinx_pale_ale.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Dextrin",
+        "name": "Dextrin Malt",
         "amount": {
           "value": 0.180,
           "unit": "kilograms"

--- a/data/juniper_wheat_beer.json
+++ b/data/juniper_wheat_beer.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 2.75,
           "unit": "kilograms"

--- a/data/kamikaze_knitting_club.json
+++ b/data/kamikaze_knitting_club.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "caramalt",
+        "name": "Caramalt",
         "amount": {
           "value": 0.840,
           "unit": "kilograms"
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Carafa Special III",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.180,
           "unit": "kilograms"

--- a/data/kingpin.json
+++ b/data/kingpin.json
@@ -99,7 +99,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 2007 – Pilsen Lager™"
+    "yeast": "Wyeast 2007 - Pilsen Lager™"
   },
   "food_pairing": [
     "Jamaican jerk chicken wings",

--- a/data/kingpin.json
+++ b/data/kingpin.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Pale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 1.50,
           "unit": "kilograms"

--- a/data/lost_dog.json
+++ b/data/lost_dog.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Oats",
+        "name": "Flaked Oats",
         "amount": {
           "value": 0.47,
           "unit": "kilograms"

--- a/data/mallow_mafia.json
+++ b/data/mallow_mafia.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Black",
+        "name": "Black Malt",
         "amount": {
           "value": 0.480,
           "unit": "kilograms"

--- a/data/manic_mango.json
+++ b/data/manic_mango.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Un-crushed Wheat",
+        "name": "Uncrushed Wheat",
         "amount": {
           "value": 0.600,
           "unit": "kilograms"

--- a/data/mashtag_2014.json
+++ b/data/mashtag_2014.json
@@ -81,7 +81,7 @@
         "attribute": "bitter"
       },
       {
-        "name": "Hallertauer Mittelfruh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 19,
           "unit": "grams"

--- a/data/mashtag_2015.json
+++ b/data/mashtag_2015.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 6.35,
           "unit": "kilograms"

--- a/data/mashtag_2016.json
+++ b/data/mashtag_2016.json
@@ -139,7 +139,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 - American Ale™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Confit duck with cherry sauce",

--- a/data/mixtape_8.json
+++ b/data/mixtape_8.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Cara",
+        "name": "Caramalt",
         "amount": {
           "value": 0.94,
           "unit": "kilograms"

--- a/data/monk_hammer.json
+++ b/data/monk_hammer.json
@@ -132,7 +132,7 @@
         "attribute": "aroma"
       }
     ],
-    "yeast": "Wyeast 3522 – Belgian Ardennes™"
+    "yeast": "Wyeast 3522 - Belgian Ardennes™"
   },
   "food_pairing": [
     "Pesto chicken pizza",

--- a/data/movember.json
+++ b/data/movember.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Extra Pale - Maris Otter",
+        "name": "Maris Otter Extra Pale",
         "amount": {
           "value": 3.44,
           "unit": "kilograms"

--- a/data/mr_miyagis_wasabi_stout.json
+++ b/data/mr_miyagis_wasabi_stout.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Chocolate Malt",
+        "name": "Chocolate",
         "amount": {
           "value": 0.5,
           "unit": "kilograms"
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Crystal Malt",
+        "name": "Crystal",
         "amount": {
           "value": 0.5,
           "unit": "kilograms"

--- a/data/native_son.json
+++ b/data/native_son.json
@@ -146,7 +146,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Gazpacho soup",

--- a/data/nelson_sauvin.json
+++ b/data/nelson_sauvin.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Xpale",
+        "name": "Extra Pale",
         "amount": {
           "value": 6.38,
           "unit": "kilograms"

--- a/data/neverland.json
+++ b/data/neverland.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Acidulated",
+        "name": "Acidulated Malt",
         "amount": {
           "value": 0.060,
           "unit": "kilograms"

--- a/data/neverland.json
+++ b/data/neverland.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Viena",
+        "name": "Vienna",
         "amount": {
           "value": 0.240,
           "unit": "kilograms"

--- a/data/new_england_ipa.json
+++ b/data/new_england_ipa.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Propino",
+        "name": "Propino Pale Malt",
         "amount": {
           "value": 3.4,
           "unit": "kilograms"

--- a/data/new_england_ipa.json
+++ b/data/new_england_ipa.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Torrefied Wheat",
+        "name": "Torrified Wheat",
         "amount": {
           "value": 0.39,
           "unit": "kilograms"

--- a/data/nine_to_five_wizard.json
+++ b/data/nine_to_five_wizard.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Double Roast Crystal",
+        "name": "Double Roasted Crystal",
         "amount": {
           "value": 0.120,
           "unit": "kilograms"

--- a/data/nine_to_five_wizard.json
+++ b/data/nine_to_five_wizard.json
@@ -128,7 +128,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 3638 Bavarian Wheat"
+    "yeast": "Wyeast 3638 - Bavarian Wheat™"
   },
   "food_pairing": [
     "Grilled Portobello Mushroom Burger",

--- a/data/old_world_india_pale_ale.json
+++ b/data/old_world_india_pale_ale.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Maris Otter Extra pale",
+        "name": "Maris Otter Extra Pale",
         "amount": {
           "value": 6.25,
           "unit": "kilograms"

--- a/data/paradox_grain_2018.json
+++ b/data/paradox_grain_2018.json
@@ -77,14 +77,14 @@
         }
       },
       {
-        "name": "Carafa Special Type III",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.5,
           "unit": "kilograms"
         }
       },
       {
-        "name": "Carafa Special Type I",
+        "name": "Carafa Special Malt Type 1",
         "amount": {
           "value": 0.25,
           "unit": "kilograms"

--- a/data/paradox_grain_2018.json
+++ b/data/paradox_grain_2018.json
@@ -129,7 +129,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 - American Ale 11™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "PB&J sandwich",

--- a/data/paradox_rye.json
+++ b/data/paradox_rye.json
@@ -129,7 +129,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 - American Ale 11™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Char-grilled Lamb Cutlets",

--- a/data/paradox_rye.json
+++ b/data/paradox_rye.json
@@ -77,14 +77,14 @@
         }
       },
       {
-        "name": "Carafa Special Type I",
+        "name": "Carafa Special Malt Type 1",
         "amount": {
           "value": 0.25,
           "unit": "kilograms"
         }
       },
       {
-        "name": "Carafa Special Type III",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.5,
           "unit": "kilograms"

--- a/data/pina_colada_sidewalk.json
+++ b/data/pina_colada_sidewalk.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Acidulated",
+        "name": "Acidulated Malt",
         "amount": {
           "value": 0.287,
           "unit": "kilograms"

--- a/data/pina_colada_sidewalk.json
+++ b/data/pina_colada_sidewalk.json
@@ -142,7 +142,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "White Chocolate and Pistachio Cheesecake",

--- a/data/prototype_27.json
+++ b/data/prototype_27.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Crystal Malt 150",
+        "name": "Crystal 150",
         "amount": {
           "value": 0.28,
           "unit": "kilograms"

--- a/data/prototype_27.json
+++ b/data/prototype_27.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 8.13,
           "unit": "kilograms"

--- a/data/prototype_black_rye_ipa.json
+++ b/data/prototype_black_rye_ipa.json
@@ -133,7 +133,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Guacamole And Chips",

--- a/data/prototype_black_rye_ipa.json
+++ b/data/prototype_black_rye_ipa.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Carafa Special III",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.180,
           "unit": "kilograms"

--- a/data/prototype_blonde_ale.json
+++ b/data/prototype_blonde_ale.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Cara Pils",
+        "name": "Carapils",
         "amount": {
           "value": 0.240,
           "unit": "kilograms"

--- a/data/prototype_double_ipa.json
+++ b/data/prototype_double_ipa.json
@@ -139,7 +139,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Hot Wings And Blue Cheese Dip",

--- a/data/science_ipa.json
+++ b/data/science_ipa.json
@@ -71,7 +71,7 @@
         }
       },
       {
-        "name": "Dark Crystal Malt",
+        "name": "Dark Crystal",
         "amount": {
           "value": 0.35,
           "unit": "kilograms"

--- a/data/science_ipa.json
+++ b/data/science_ipa.json
@@ -98,7 +98,7 @@
         "attribute": "flavour"
       },
       {
-        "name": "Amarilo",
+        "name": "Amarillo",
         "amount": {
           "value": 40,
           "unit": "grams"

--- a/data/self_assembly_pope.json
+++ b/data/self_assembly_pope.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Dextrin",
+        "name": "Dextrin Malt",
         "amount": {
           "value": 0.2,
           "unit": "kilograms"

--- a/data/semi_skimmed_occultist.json
+++ b/data/semi_skimmed_occultist.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Carafa Special I",
+        "name": "Carafa Special Malt Type 1",
         "amount": {
           "value": 0.4,
           "unit": "kilograms"

--- a/data/shareholder_black_ipa_2011.json
+++ b/data/shareholder_black_ipa_2011.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Cara",
+        "name": "Caramalt",
         "amount": {
           "value": 0.75,
           "unit": "kilograms"

--- a/data/sidewalk_shark.json
+++ b/data/sidewalk_shark.json
@@ -124,7 +124,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Grilled Halibut",

--- a/data/sidewalk_shark.json
+++ b/data/sidewalk_shark.json
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Acidulated",
+        "name": "Acidulated Malt",
         "amount": {
           "value": 0.283,
           "unit": "kilograms"

--- a/data/slot_machine.json
+++ b/data/slot_machine.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Carafa Special III",
+        "name": "Carafa Special Malt Type 3",
         "amount": {
           "value": 0.120,
           "unit": "kilograms"

--- a/data/slot_machine.json
+++ b/data/slot_machine.json
@@ -144,7 +144,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1056 - American Ale"
+    "yeast": "Wyeast 1056 - American Ale™"
   },
   "food_pairing": [
     "Barbeque and Mustard Beef on Rye Bread",

--- a/data/small_batch_90_shilling.json
+++ b/data/small_batch_90_shilling.json
@@ -113,7 +113,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1056 -American Ale™"
+    "yeast": "Wyeast 1056 - American Ale™"
   },
   "food_pairing": [
     "Game Terrine",

--- a/data/small_batch_90_shilling.json
+++ b/data/small_batch_90_shilling.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Propino",
+        "name": "Propino Pale Malt",
         "amount": {
           "value": 5.6,
           "unit": "kilograms"

--- a/data/small_batch_cranachan_cream_ale.json
+++ b/data/small_batch_cranachan_cream_ale.json
@@ -137,7 +137,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1272 American Ale II™"
+    "yeast": "Wyeast 1272 - American Ale II™"
   },
   "food_pairing": [
     "Gingerbread Man",

--- a/data/small_batch_dry_hopped_pilsner.json
+++ b/data/small_batch_dry_hopped_pilsner.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "carapils",
+        "name": "Carapils",
         "amount": {
           "value": 0.240,
           "unit": "kilograms"

--- a/data/small_batch_imperial_pale_weizen.json
+++ b/data/small_batch_imperial_pale_weizen.json
@@ -119,7 +119,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "WLP351 Bavarian Weizen"
+    "yeast": "WLP351 - Bavarian Weizen"
   },
   "food_pairing": [
     "Soft pretzel with mustard",

--- a/data/small_batch_kellerbier.json
+++ b/data/small_batch_kellerbier.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Propino",
+        "name": "Propino Pale Malt",
         "amount": {
           "value": 1.2,
           "unit": "kilograms"

--- a/data/small_batch_lemon_meringue_pie.json
+++ b/data/small_batch_lemon_meringue_pie.json
@@ -42,14 +42,14 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Marris Otter",
+        "name": "Maris Otter",
         "amount": {
           "value": 4.533,
           "unit": "kilograms"
         }
       },
       {
-        "name": "Dextrin Malt",
+        "name": "Dextrin",
         "amount": {
           "value": 0.567,
           "unit": "kilograms"

--- a/data/small_batch_lemon_meringue_pie.json
+++ b/data/small_batch_lemon_meringue_pie.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Dextrin",
+        "name": "Dextrin Malt",
         "amount": {
           "value": 0.567,
           "unit": "kilograms"

--- a/data/small_batch_nitro_breakfast_stout.json
+++ b/data/small_batch_nitro_breakfast_stout.json
@@ -77,7 +77,7 @@
         }
       },
       {
-        "name": "Carafa Special Type I",
+        "name": "Carafa Special Malt Type 1",
         "amount": {
           "value": 0.19,
           "unit": "kilograms"

--- a/data/small_batch_nitro_breakfast_stout.json
+++ b/data/small_batch_nitro_breakfast_stout.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Oats",
+        "name": "Flaked Oats",
         "amount": {
           "value": 0.62,
           "unit": "kilograms"

--- a/data/small_batch_rye_ipa.json
+++ b/data/small_batch_rye_ipa.json
@@ -63,7 +63,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Marris Otter",
+        "name": "Maris Otter",
         "amount": {
           "value": 4,
           "unit": "kilograms"

--- a/data/small_batch_sorachi_ace_session.json
+++ b/data/small_batch_sorachi_ace_session.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Rye - Crisp",
+        "name": "Crisp Rye",
         "amount": {
           "value": 0.22,
           "unit": "kilograms"
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Acidulated",
+        "name": "Acidulated Malt",
         "amount": {
           "value": 0.06,
           "unit": "kilograms"

--- a/data/small_batch_sorachi_ace_session.json
+++ b/data/small_batch_sorachi_ace_session.json
@@ -97,7 +97,7 @@
         "attribute": "Flavour"
       }
     ],
-    "yeast": "Wyeast 1388 – Belgian Strong Ale™"
+    "yeast": "Wyeast 1388 - Belgian Strong Ale™"
   },
   "food_pairing": [
     "Californian Sushi Roll",

--- a/data/small_batch_vermont_ipa.json
+++ b/data/small_batch_vermont_ipa.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Marris Otter",
+        "name": "Maris Otter",
         "amount": {
           "value": 0.8,
           "unit": "kilograms"

--- a/data/small_batch_vermont_ipa_v2.json
+++ b/data/small_batch_vermont_ipa_v2.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Propino",
+        "name": "Propino Pale Malt",
         "amount": {
           "value": 3.3,
           "unit": "kilograms"

--- a/data/small_batch_vermont_ipa_v2.json
+++ b/data/small_batch_vermont_ipa_v2.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Marris Otter",
+        "name": "Maris Otter",
         "amount": {
           "value": 0.8,
           "unit": "kilograms"

--- a/data/sorachi_ace.json
+++ b/data/sorachi_ace.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Xpale",
+        "name": "Extra Pale",
         "amount": {
           "value": 6.38,
           "unit": "kilograms"

--- a/data/sos_may_day.json
+++ b/data/sos_may_day.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Acidulated",
+        "name": "Acidulated Malt",
         "amount": {
           "value": 0.060,
           "unit": "kilograms"
@@ -81,7 +81,7 @@
         "attribute": "Bittering"
       },
       {
-        "name": "Hallertauer Mittelfruh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 10,
           "unit": "grams"
@@ -90,7 +90,7 @@
         "attribute": "Flavour"
       },
       {
-        "name": "Hallertauer Mittelfruh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 20,
           "unit": "grams"
@@ -99,7 +99,7 @@
         "attribute": "Aroma"
       },
       {
-        "name": "Hallertauer Mittelfruh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 20,
           "unit": "grams"
@@ -126,7 +126,7 @@
         "attribute": "Aroma"
       },
       {
-        "name": "Hallertauer Mittelfruh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 20,
           "unit": "grams"

--- a/data/spiced_cherry_sour.json
+++ b/data/spiced_cherry_sour.json
@@ -84,7 +84,7 @@
         }
       },
       {
-        "name": "Acidulated malt",
+        "name": "Acidulated Malt",
         "amount": {
           "value": 0.63,
           "unit": "kilograms"

--- a/data/sub_hop.json
+++ b/data/sub_hop.json
@@ -128,7 +128,7 @@
         "attribute": "aroma"
       }
     ],
-    "yeast": "Wyeast 2007- Pilsen Lager™"
+    "yeast": "Wyeast 2007 - Pilsen Lager™"
   },
   "food_pairing": [
     "Seared lemon and herb salmon",

--- a/data/sub_hop.json
+++ b/data/sub_hop.json
@@ -74,7 +74,7 @@
         "attribute": "bitter"
       },
       {
-        "name": "Hallertauer Mittelfrüh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 12.5,
           "unit": "grams"

--- a/data/sunshine_on_rye.json
+++ b/data/sunshine_on_rye.json
@@ -70,7 +70,7 @@
         }
       },
       {
-        "name": "Rye Malt",
+        "name": "Rye",
         "amount": {
           "value": 0.63,
           "unit": "kilograms"

--- a/data/tactical_nuclear_penguin.json
+++ b/data/tactical_nuclear_penguin.json
@@ -135,7 +135,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "WLP099 Super High Gravity Ale"
+    "yeast": "WLP099 - Super High Gravity Ale"
   },
   "food_pairing": [
     "Lobster thermidor",

--- a/data/tm10.json
+++ b/data/tm10.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Malt",
+        "name": "Pale Ale",
         "amount": {
           "value": 5.3,
           "unit": "kilograms"

--- a/data/tokyo.json
+++ b/data/tokyo.json
@@ -135,7 +135,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "WLP099 Super High Gravity Ale"
+    "yeast": "WLP099 - Super High Gravity Ale"
   },
   "food_pairing": [
     "Herbal roast beef with a cranberry jus",

--- a/data/tokyo_rising_sun_highland.json
+++ b/data/tokyo_rising_sun_highland.json
@@ -135,7 +135,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "WLP099 Super High Gravity Ale"
+    "yeast": "WLP099 - Super High Gravity Ale"
   },
   "food_pairing": [
     "Chorizo cooked in red wine",

--- a/data/tokyo_rising_sun_lowland.json
+++ b/data/tokyo_rising_sun_lowland.json
@@ -135,7 +135,7 @@
         "attribute": "flavour"
       }
     ],
-    "yeast": "WLP099 Super High Gravity Ale"
+    "yeast": "WLP099 - Super High Gravity Ale"
   },
   "food_pairing": [
     "Duck liver paté",

--- a/data/tropic_thunder.json
+++ b/data/tropic_thunder.json
@@ -42,7 +42,7 @@
   "ingredients": {
     "malt": [
       {
-        "name": "Pale Ale Propino",
+        "name": "Propino Pale Malt",
         "amount": {
           "value": 3.8,
           "unit": "kilograms"
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Premium English Cara",
+        "name": "Premium English Caramalt",
         "amount": {
           "value": 0.3,
           "unit": "kilograms"

--- a/data/twin_atlantic.json
+++ b/data/twin_atlantic.json
@@ -49,7 +49,7 @@
         }
       },
       {
-        "name": "Cara Malt",
+        "name": "Caramalt",
         "amount": {
           "value": 0.2,
           "unit": "kilograms"

--- a/data/twin_atlantic.json
+++ b/data/twin_atlantic.json
@@ -76,7 +76,7 @@
         "attribute": "Aroma"
       }
     ],
-    "yeast": "Wyeast 1056 – American Ale™"
+    "yeast": "Wyeast 1056 - American Ale™"
   },
   "food_pairing": [
     "Jerk Chicken Kebabs with Mango Salsa",

--- a/data/u_boat.json
+++ b/data/u_boat.json
@@ -86,7 +86,7 @@
     ],
     "hops": [
       {
-        "name": "Hallertauer Mittelfrüh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 7.5,
           "unit": "grams"
@@ -95,7 +95,7 @@
         "attribute": "bitter"
       },
       {
-        "name": "Hallertauer Mittelfrüh",
+        "name": "Hallertauer Mittelfrüh",
         "amount": {
           "value": 11.5,
           "unit": "grams"

--- a/data/vagabond_pilsner.json
+++ b/data/vagabond_pilsner.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Acidulated malt",
+        "name": "Acidulated Malt",
         "amount": {
           "value": 0.63,
           "unit": "kilograms"

--- a/data/whisky_sour.json
+++ b/data/whisky_sour.json
@@ -84,7 +84,7 @@
         }
       },
       {
-        "name": "Rye Malt",
+        "name": "Rye",
         "amount": {
           "value": 0.25,
           "unit": "kilograms"

--- a/data/white_noise.json
+++ b/data/white_noise.json
@@ -63,7 +63,7 @@
         }
       },
       {
-        "name": "Oats",
+        "name": "Flaked Oats",
         "amount": {
           "value": 0.31,
           "unit": "kilograms"


### PR DESCRIPTION
I've made a few updates to the ingredients in some of the recipes -

- Aligned the names of the yeasts so that the same yeast strain uses the same name throughout, using the descriptive name from the manufacturer.
- Made some of the yeast naming more consistent, e.g., the Wyeasts are always in the format '&lt;strain name&gt; - &lt;descriptive name&gt;'.
- Add missing yeast to Choco Libre.
- Made some of the malt names more consistent, e.g., always use 'Dark Crystal' instead of 'Crystal Dark' - I avoided changing too much here since many of the specific malts used in DIY Dog are down to interpretation.
- Fixed various typos.

Cheers,
Stuart.